### PR TITLE
fix: Prevent User File Input over 6MB

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -46,7 +46,9 @@ export default function Form({ title, questions, listingId, includeEventsAttende
   const [formData, setFormData] = useState<FormData>(initialValues);
   const [resumeFileName, setResumeFileName] = useState<String>("");
   const [imageFileName, setImageFileName] = useState<String>("");
-  const [remainingFileSize, setRemainingFileSize] = useState<number>(6);
+  const [resumeFileSize, setResumeFileSize] = useState<number>(0);
+  const [imageFileSize, setImageFileSize] = useState<number>(0);
+  const MAX_FILE_SIZE = 6
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   if (includeEventsAttended) {
@@ -220,6 +222,12 @@ export default function Form({ title, questions, listingId, includeEventsAttende
     }));
   };
 
+  const convertToMB = (bytes: number) => {
+    // 1 megabyte = 1e6 bytes
+    const megabytes = bytes / (1e6);
+    return megabytes;
+  }
+  console.log(resumeFileSize, imageFileSize)
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
     const file = e.target.files ? e.target.files[0] : null;
@@ -244,11 +252,26 @@ export default function Form({ title, questions, listingId, includeEventsAttende
         return;
       }
 
-      // TO-DO: Perform file size validation
-      console.log("here is the file", file)
+      // Perform file size conversion (bytes -> megabytes)
+      const fileSize = convertToMB(file.size);
+      
       if (id === "resume") {
+        // handle large files
+        if (imageFileSize + fileSize > MAX_FILE_SIZE) {
+          alert(`Resume file size of ${fileSize.toFixed(2)} MB is too large.`);
+          return;
+        }
+
+        setResumeFileSize(fileSize);
         setResumeFileName(file.name);
       } else if (id === "image") {
+        // handle large files
+        if (resumeFileSize + fileSize > MAX_FILE_SIZE) {
+          alert(`Image file size of ${fileSize.toFixed(2)} MB is too large.`);
+          return;
+        }
+
+        setImageFileSize(fileSize);
         setImageFileName(file.name);
       }
       // Read the file as a base64 string
@@ -262,6 +285,14 @@ export default function Form({ title, questions, listingId, includeEventsAttende
       };
       reader.readAsDataURL(file);
     } else {
+
+      // reset file size validation
+      if (id === "resume") {
+        setResumeFileSize(0);
+      } else if (id === "image") {
+        setImageFileSize(0);
+      }
+
       // Clear the file or base64 property if no file is selected
       setFormData((prevData) => ({
         ...prevData,

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -46,6 +46,7 @@ export default function Form({ title, questions, listingId, includeEventsAttende
   const [formData, setFormData] = useState<FormData>(initialValues);
   const [resumeFileName, setResumeFileName] = useState<String>("");
   const [imageFileName, setImageFileName] = useState<String>("");
+  const [remainingFileSize, setRemainingFileSize] = useState<number>(6);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   if (includeEventsAttended) {
@@ -195,8 +196,8 @@ export default function Form({ title, questions, listingId, includeEventsAttende
         }));
       }
     } else if (id === "gradYear") {
-      // case 2 : handle grad year (only accept integers)
-      if (Number.isInteger(Number(value))) {
+      // case 2 : handle grad year (only accept positive integers)
+      if (Number.isInteger(Number(value)) && Number(value) >= 0) {
         setFormData((prevData) => ({
           ...prevData,
           [id]: value,
@@ -237,12 +238,14 @@ export default function Form({ title, questions, listingId, includeEventsAttende
     }
 
     if (file) {
-      // Perform file validation
+      // Perform file validation (TO-DO: add parameter to for resume/photo for the specific type)
       if (!validateFileType(file)) {
         alert('Invalid file type. Please upload a PDF, JPG, JPEG, or PNG file.');
         return;
       }
 
+      // TO-DO: Perform file size validation
+      console.log("here is the file", file)
       if (id === "resume") {
         setResumeFileName(file.name);
       } else if (id === "image") {
@@ -295,7 +298,6 @@ export default function Form({ title, questions, listingId, includeEventsAttende
       }));
     }
   }
-  console.log()
 
   const handleEventsAttendedChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = e.target;

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -240,8 +240,10 @@ export default function Form({ title, questions, listingId, includeEventsAttende
 
     // Set filename states to "" since cancelling upload makes file in form null
     if (id === "resume") {
+      setResumeFileSize(0);
       setResumeFileName("");
     } else if (id === "image") {
+      setImageFileSize(0);
       setImageFileName("");
     }
 
@@ -258,6 +260,7 @@ export default function Form({ title, questions, listingId, includeEventsAttende
       if (id === "resume") {
         // handle large files
         if (imageFileSize + fileSize > MAX_FILE_SIZE) {
+          console.log("resume to large")
           alert(`Resume file size of ${fileSize.toFixed(2)} MB is too large.`);
           return;
         }

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -48,7 +48,7 @@ export default function Form({ title, questions, listingId, includeEventsAttende
   const [imageFileName, setImageFileName] = useState<String>("");
   const [resumeFileSize, setResumeFileSize] = useState<number>(0);
   const [imageFileSize, setImageFileSize] = useState<number>(0);
-  const MAX_FILE_SIZE = 6
+  const MAX_FILE_SIZE_BYTES = 6 * 1000 * 1000
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   if (includeEventsAttended) {
@@ -231,12 +231,12 @@ export default function Form({ title, questions, listingId, includeEventsAttende
     if (id !== "resume" && id !== "image") {
       return;
     }
-    
-    // File size conversion helper function
+
+    // File conversion helper function
     const convertToMB = (bytes: number) => {
       // 1 megabyte = 1e6 bytes
       const megabytes = bytes / (1e6);
-      return megabytes;
+      return megabytes.toFixed(2);
     }
     
     // File validation helper function
@@ -271,13 +271,13 @@ export default function Form({ title, questions, listingId, includeEventsAttende
         return;
       }
 
-      // Perform file size conversion (bytes -> megabytes)
-      const fileSize = convertToMB(file.size);
+      // extract fileSize from file object
+      const fileSize = file.size
       
       if (id === "resume") {
         // handle large files
-        if (imageFileSize + fileSize > MAX_FILE_SIZE) {
-          alert(`Resume file size of ${fileSize.toFixed(2)} MB is too large.`);
+        if (imageFileSize + fileSize > MAX_FILE_SIZE_BYTES) {
+          alert(`Image file size of ${convertToMB(fileSize)} MB is too large. Total of ${convertToMB(MAX_FILE_SIZE_BYTES-imageFileSize)} MB available.`);
           return;
         }
 
@@ -285,8 +285,8 @@ export default function Form({ title, questions, listingId, includeEventsAttende
         setResumeFileName(file.name);
       } else if (id === "image") {
         // handle large files
-        if (resumeFileSize + fileSize > MAX_FILE_SIZE) {
-          alert(`Image file size of ${fileSize.toFixed(2)} MB is too large.`);
+        if (resumeFileSize + fileSize > MAX_FILE_SIZE_BYTES) {
+          alert(`Image file size of ${convertToMB(fileSize)} MB is too large. Total of ${convertToMB(MAX_FILE_SIZE_BYTES-resumeFileSize)} MB available.`);
           return;
         }
 

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -48,7 +48,7 @@ export default function Form({ title, questions, listingId, includeEventsAttende
   const [imageFileName, setImageFileName] = useState<String>("");
   const [resumeFileSize, setResumeFileSize] = useState<number>(0);
   const [imageFileSize, setImageFileSize] = useState<number>(0);
-  const MAX_FILE_SIZE_BYTES = 6 * 1000 * 1000
+  const MAX_FILE_SIZE_BYTES = 6 * 1000 * 1000 - 1
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   if (includeEventsAttended) {

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -222,20 +222,30 @@ export default function Form({ title, questions, listingId, includeEventsAttende
     }));
   };
 
-  const convertToMB = (bytes: number) => {
-    // 1 megabyte = 1e6 bytes
-    const megabytes = bytes / (1e6);
-    return megabytes;
-  }
-  console.log(resumeFileSize, imageFileSize)
+  
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id } = e.target;
     const file = e.target.files ? e.target.files[0] : null;
-
+    
+    // ensure id is in correct format
+    if (id !== "resume" && id !== "image") {
+      return;
+    }
+    
+    // File size conversion helper function
+    const convertToMB = (bytes: number) => {
+      // 1 megabyte = 1e6 bytes
+      const megabytes = bytes / (1e6);
+      return megabytes;
+    }
+    
     // File validation helper function
-    const allowedTypes = ['application/pdf', 'image/jpeg', 'image/png'];
-    const validateFileType = (selectedFile: File | null): boolean => {
-      return !!selectedFile && allowedTypes.includes(selectedFile.type);
+    const allowedTypes = {
+      resume: ['application/pdf'], 
+      image: ['image/jpeg', 'image/png']
+    }
+    const validateFileType = (selectedFile: File | null, fileId: keyof typeof allowedTypes): boolean => {
+      return !!selectedFile && allowedTypes[fileId].includes(selectedFile.type);
     };
 
     // Set filename states to "" since cancelling upload makes file in form null
@@ -248,9 +258,16 @@ export default function Form({ title, questions, listingId, includeEventsAttende
     }
 
     if (file) {
-      // Perform file validation (TO-DO: add parameter to for resume/photo for the specific type)
-      if (!validateFileType(file)) {
-        alert('Invalid file type. Please upload a PDF, JPG, JPEG, or PNG file.');
+      // Perform file validation
+      if (!validateFileType(file, id)) {
+        switch (id) {
+          case "resume":
+            alert('Invalid file type. Please upload a PDF file.');
+            break;
+          case "image":
+            alert('Invalid file type. Please upload a JPG, JPEG, or PNG file.');
+            break;
+          }
         return;
       }
 
@@ -260,7 +277,6 @@ export default function Form({ title, questions, listingId, includeEventsAttende
       if (id === "resume") {
         // handle large files
         if (imageFileSize + fileSize > MAX_FILE_SIZE) {
-          console.log("resume to large")
           alert(`Resume file size of ${fileSize.toFixed(2)} MB is too large.`);
           return;
         }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR temporarily addresses the issue of file size when sending the application through Chalice (Lambda doesn't allow payload of > 6mb). I've added a flexible variable called `MAX_FILE_SIZE` which represents the maximum number of mb that the image/resume files can take combined. It checks that this file size is not surpassed every time a file is updated.

Other small updates:
- added code to check for specific file types depending on updating image/resume respectively
- prevented negative gradYear

## Type of change

- [x] Fix: Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor: Any code refactoring
- [ ] Chore: technical debt, workflow improvements
- [ ] Feature: New feature (non-breaking change which adds functionality)
- [ ] Documentation: This change requires a documentation update

## Tests Performed

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->
Performed variety of frontend tests with different file sizes/combinations.

## Screenshots

<!-- Please attach relevant screenshots regarding the PR -->
Screen cast [link](https://drive.google.com/file/d/1CJo-LlKLU72zazbaelEenCVult1yk-c8/view?usp=sharing)


## Additional Comments
