### PR TITLE
Fixed card and image issue in ApplicantCard component

### DIFF
--- a/components/admin/listing/ApplicantCard.tsx
+++ b/components/admin/listing/ApplicantCard.tsx
@@ -25,12 +25,13 @@ export default function ApplicantCard({ applicant }: ApplicantCardProps) {
     <Card className="cursor-pointer" onClick={() => router.push(`/admin/listing/${applicant.listingId}/${applicant.applicantId}`)}>
       <div className="flex flex-col items-center mb-1">
         <Image
+          height={96}
+          width={96}
           loader={() => applicant.image}
           alt={`${applicant.firstName} ${applicant.lastName} image`}
-          className="mb-3 rounded-full shadow-lg"
-          height={96}
+          className="w-24 h-24 mb-3 shadow-lg relative mx-auto rounded-full overflow-hidden"
           src={applicant.image}
-          width={96}
+          layout="fixed"
         />
         <h5 className="mb-1 text-lg font-medium text-gray-900 dark:text-white">
           {`${applicant.firstName} ${applicant.lastName}`}


### PR DESCRIPTION
## What does this PR do?

There was an issue with card sizing where the image of the applicant would stretch the card more than it needs to. 

```html
        <Image
          height={96}
          width={96}
          loader={() => applicant.image}
          alt={`${applicant.firstName} ${applicant.lastName} image`}
          className="w-24 h-24 mb-3 shadow-lg relative mx-auto rounded-full overflow-hidden"
          src={applicant.image}
          layout="fixed"
        />
```

By adding `w-24 h-24`, we can set a fixed size for element. `height` and `width` only changes the size of the original image file.

## Type of change

- [x] Fix: Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor: Any code refactoring
- [ ] Chore: technical debt, workflow improvements
- [ ] Feature: New feature (non-breaking change which adds functionality)
- [ ] Documentation: This change requires a documentation update

## Tests Performed

## Screenshots

## Additional Comments
