### PR TITLE
Feat/enable rush event cover image

### DIFF
--- a/app/admin/rush/page.tsx
+++ b/app/admin/rush/page.tsx
@@ -126,7 +126,7 @@ export default function RushEvents() {
       <Card key={index} className={`hover:bg-gray-100 dark:hover:bg-gray-800 cursor-pointer mb-3`}>
         <div className="flex flex-row items-center w-full">
           <div className="flex-1">
-            <Link href={`/admin/rush/${event.eventId}`}>
+            <Link href={`/admin/rush/${event._id}`}>
               <div className="flex items-center px-2 space-x-4">
                 <div className="shrink-0">
                   <Avatar placeholderInitials={event.name[0]} rounded />
@@ -195,9 +195,9 @@ export default function RushEvents() {
                   eventLocation: event.location,
                   eventDate: new Date(event.date),
                   eventDeadline: new Date(event.deadline),
-                  eventCoverImage: "", // TODO: replace with image from backend...
-                  eventCoverImageName: "", // TODO: replace with image from backend...
-                  eventId: event.eventId,
+                  eventCoverImage: event.eventCoverImage,
+                  eventCoverImageName: event.eventCoverImageName,
+                  eventId: event._id,
                 });
                 setOpenModifyEventModal(true);
               }}
@@ -209,8 +209,8 @@ export default function RushEvents() {
             }} className="w-5 h-5 text-gray-800 transition duration-200 ease-in-out hover:text-purple-600 mr-1" />
             <a
               href={process.env.NEXT_PUBLIC_API_BASE_URL === 'http://127.0.0.1:8000'
-                ? `https://staging--whyphi-rush.netlify.app/checkin/${event.eventId}`
-                : `https://rush.why-phi.com/checkin/${event.eventId}`
+                ? `https://staging--whyphi-rush.netlify.app/checkin/${event._id}`
+                : `https://rush.why-phi.com/checkin/${event._id}`
               }
               target="_blank"
               rel="noopener"
@@ -221,9 +221,8 @@ export default function RushEvents() {
           </div>
         </div>
       </Card>
-
     )
-  }
+  }  
 
   // handleRusheeEvent : by default creates a rush event
   const handleRusheeEvent = async (modifying?: boolean) => {
@@ -251,7 +250,7 @@ export default function RushEvents() {
           deadline: eventFormData.eventDeadline.toISOString(),
           eventCoverImage : eventFormData.eventCoverImage,
           eventCoverImageName : eventFormData.eventCoverImageName,
-          ...(modifying && { eventId: eventFormData.eventId })
+          ...(modifying && { _id: eventFormData.eventId })
         })
       })
       if (!response.ok) {
@@ -269,7 +268,7 @@ export default function RushEvents() {
   const handleDeleteEvent = async () => {
     console.log("hit")
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/events/rush/${selectedEventToDelete?.eventId}`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/events/rush/${selectedEventToDelete?._id}`, {
         method: 'DELETE',
         headers: {
           Authorization: `Bearer ${token}`,

--- a/app/admin/rush/page.tsx
+++ b/app/admin/rush/page.tsx
@@ -23,6 +23,7 @@ export interface EventFormData {
   eventLocation: string,
   eventDate: Date,
   eventDeadline: Date,
+  eventCoverImage: File | null,
   eventId?: string,
 }
 
@@ -31,6 +32,7 @@ const initialValues: EventFormData = {
   eventCode: "",
   eventLocation: "",
   eventDate: new Date(),
+  eventCoverImage: null,
   eventDeadline: addTwoHours(new Date()),
 };
 
@@ -189,6 +191,7 @@ export default function RushEvents() {
                   eventLocation: event.location,
                   eventDate: new Date(event.date),
                   eventDeadline: new Date(event.deadline),
+                  eventCoverImage: null, // TODO: replace with image from backend...
                   eventId: event.eventId,
                 });
                 setOpenModifyEventModal(true);
@@ -295,7 +298,7 @@ export default function RushEvents() {
   }
 
   if (isLoading) return <Loader />;
-
+  
   return (
     <div className="overflow-x-auto">
       <div className="flex justify-between items-center">

--- a/app/admin/rush/page.tsx
+++ b/app/admin/rush/page.tsx
@@ -298,6 +298,9 @@ export default function RushEvents() {
   }
 
   if (isLoading) return <Loader />;
+
+  console.log("eventCoverImage", eventFormData.eventCoverImage);
+  
   
   return (
     <div className="overflow-x-auto">

--- a/app/admin/rush/page.tsx
+++ b/app/admin/rush/page.tsx
@@ -43,6 +43,8 @@ export default function RushEvents() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [rushCategories, setRushCategories] = useState<RushCategory[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
 
   const [eventFormData, setEventFormData] = useState<EventFormData>(initialValues);
 
@@ -230,6 +232,9 @@ export default function RushEvents() {
       alert('Event code cannot contain whitespace. Please check that you are not using whitespaces in your event code.');
       return;
     }
+    // ensure buttons cannot be clicked twice while API is submitting
+    setIsSubmitting(true);
+
     try {
       const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/events/rush`, {
         method: `${modifying ? 'PATCH' : 'POST'}`,
@@ -245,6 +250,7 @@ export default function RushEvents() {
           date: eventFormData.eventDate.toISOString(),
           deadline: eventFormData.eventDeadline.toISOString(),
           eventCoverImage : eventFormData.eventCoverImage,
+          eventCoverImageName : eventFormData.eventCoverImageName,
           ...(modifying && { eventId: eventFormData.eventId })
         })
       })
@@ -255,6 +261,8 @@ export default function RushEvents() {
     } catch (error) {
       // TODO: handle error
       console.error(error);
+    } finally {
+      setIsSubmitting(false);
     }
   }
 
@@ -355,6 +363,7 @@ export default function RushEvents() {
         showModal={openCreateEventModal}
         selectedRushCategory={selectedRushCategory}
         eventFormData={eventFormData}
+        isSubmitting={isSubmitting}
         setEventFormData={setEventFormData}
         onClose={onCloseCreateEventModal}
         onSubmit={() => handleRusheeEvent()}
@@ -364,6 +373,7 @@ export default function RushEvents() {
         showModal={openModifyEventModal}
         selectedRushCategory={selectedRushCategory}
         eventFormData={eventFormData}
+        isSubmitting={isSubmitting}
         setEventFormData={setEventFormData}
         onClose={onCloseModifyEventModal}
         onSubmit={() => handleRusheeEvent(true)}

--- a/app/admin/rush/page.tsx
+++ b/app/admin/rush/page.tsx
@@ -23,7 +23,8 @@ export interface EventFormData {
   eventLocation: string,
   eventDate: Date,
   eventDeadline: Date,
-  eventCoverImage: File | null,
+  eventCoverImage: string,
+  eventCoverImageName: string,
   eventId?: string,
 }
 
@@ -32,7 +33,8 @@ const initialValues: EventFormData = {
   eventCode: "",
   eventLocation: "",
   eventDate: new Date(),
-  eventCoverImage: null,
+  eventCoverImage: "",
+  eventCoverImageName: "",
   eventDeadline: addTwoHours(new Date()),
 };
 
@@ -191,7 +193,8 @@ export default function RushEvents() {
                   eventLocation: event.location,
                   eventDate: new Date(event.date),
                   eventDeadline: new Date(event.deadline),
-                  eventCoverImage: null, // TODO: replace with image from backend...
+                  eventCoverImage: "", // TODO: replace with image from backend...
+                  eventCoverImageName: "", // TODO: replace with image from backend...
                   eventId: event.eventId,
                 });
                 setOpenModifyEventModal(true);
@@ -241,6 +244,7 @@ export default function RushEvents() {
           location: eventFormData.eventLocation,
           date: eventFormData.eventDate.toISOString(),
           deadline: eventFormData.eventDeadline.toISOString(),
+          eventCoverImage : eventFormData.eventCoverImage,
           ...(modifying && { eventId: eventFormData.eventId })
         })
       })
@@ -299,8 +303,6 @@ export default function RushEvents() {
 
   if (isLoading) return <Loader />;
 
-  console.log("eventCoverImage", eventFormData.eventCoverImage);
-  
   return (
     <div className="overflow-x-auto">
       <div className="flex justify-between items-center">

--- a/app/admin/rush/page.tsx
+++ b/app/admin/rush/page.tsx
@@ -301,7 +301,6 @@ export default function RushEvents() {
 
   console.log("eventCoverImage", eventFormData.eventCoverImage);
   
-  
   return (
     <div className="overflow-x-auto">
       <div className="flex justify-between items-center">

--- a/components/admin/rush/CreateDrawer.tsx
+++ b/components/admin/rush/CreateDrawer.tsx
@@ -1,11 +1,9 @@
 "use client"
 
 import React, { useState, useEffect } from 'react';
-import { HiOutlineUserGroup, HiOutlinePlus, HiOutlineX } from "react-icons/hi";
-import { Label, TextInput, Button, Select, Badge } from 'flowbite-react';
+import { HiOutlineUserGroup } from "react-icons/hi";
+import { Label, TextInput, Button } from 'flowbite-react';
 import { useAuth } from "@/app/contexts/AuthContext";
-import { Timeframe } from "@/types/admin/events";
-import { Spinner } from 'flowbite-react';
 
 interface CreateDrawerProps {
   onClose: () => void; // Prop for close button click handler
@@ -54,9 +52,7 @@ const CreateDrawer: React.FC<CreateDrawerProps> = ({ onClose }) => {
       console.error(error);
     }
   }
-
-
-
+ 
   return (
     <div
       style={{ transform: `translateX(${translateX})` }}

--- a/components/admin/rush/EventModal.tsx
+++ b/components/admin/rush/EventModal.tsx
@@ -52,7 +52,7 @@ export default function EventModal({
 							<Label htmlFor="eventCoverImage" value="Event Cover Image" />
 							<span className="text-red-500"> *</span>
 						</div>
-						<CropImage onChange={(croppedImage) => setEventFormData({ ...eventFormData, eventCoverImage: croppedImage })} />
+						<CropImage onChange={(eventCoverImage) => setEventFormData({ ...eventFormData, eventCoverImage: eventCoverImage })} />
 					</div>
 					<div>
 						<div className="mb-2 block">

--- a/components/admin/rush/EventModal.tsx
+++ b/components/admin/rush/EventModal.tsx
@@ -2,14 +2,15 @@ import { EventFormData } from "@/app/admin/rush/page";
 import { RushCategory } from "@/types/admin/events";
 import { addTwoHours } from "@/utils/date";
 import { Button, Label, Modal, TextInput } from "flowbite-react";
+import { AiOutlineLoading } from "react-icons/ai";
 import DatePicker from "react-datepicker";
-import { CanvasPreview } from "./Image/CanvasPreview";
 import CropImage from "./Image/CropImage";
 
 interface EventModalProps {
 	showModal: boolean,
 	selectedRushCategory: RushCategory | null,
 	eventFormData: EventFormData,
+	isSubmitting: boolean,
 	setEventFormData: React.Dispatch<React.SetStateAction<EventFormData>>,
 	onClose: () => void,
 	onSubmit: () => void,
@@ -21,6 +22,7 @@ export default function EventModal({
 	showModal,
 	selectedRushCategory,
 	eventFormData,
+	isSubmitting,
 	setEventFormData,
 	onClose,
 	onSubmit,
@@ -135,8 +137,11 @@ export default function EventModal({
 								!eventFormData.eventDate ||
 								!eventFormData.eventDeadline ||
 								!eventFormData.eventLocation ||
-								!eventFormData.eventCoverImage
+								!eventFormData.eventCoverImage ||
+								isSubmitting
 							}
+							isProcessing={isSubmitting}
+							processingSpinner={isSubmitting && <AiOutlineLoading className="h-6 w-6 animate-spin" />}
 							onClick={onSubmit}
 						>
 							{modifyingEvent ? "Modify Event" : "Create Event"}

--- a/components/admin/rush/EventModal.tsx
+++ b/components/admin/rush/EventModal.tsx
@@ -127,7 +127,8 @@ export default function EventModal({
 								!eventFormData.eventCode ||
 								!eventFormData.eventDate ||
 								!eventFormData.eventDeadline ||
-								!eventFormData.eventLocation
+								!eventFormData.eventLocation ||
+								!eventFormData.eventCoverImage
 							}
 							onClick={onSubmit}
 						>

--- a/components/admin/rush/EventModal.tsx
+++ b/components/admin/rush/EventModal.tsx
@@ -52,7 +52,7 @@ export default function EventModal({
 							<Label htmlFor="eventCoverImage" value="Event Cover Image" />
 							<span className="text-red-500"> *</span>
 						</div>
-						<CropImage />
+						<CropImage onChange={(croppedImage) => setEventFormData({ ...eventFormData, eventCoverImage: croppedImage })} />
 					</div>
 					<div>
 						<div className="mb-2 block">

--- a/components/admin/rush/EventModal.tsx
+++ b/components/admin/rush/EventModal.tsx
@@ -52,7 +52,14 @@ export default function EventModal({
 							<Label htmlFor="eventCoverImage" value="Event Cover Image" />
 							<span className="text-red-500"> *</span>
 						</div>
-						<CropImage onChange={(eventCoverImage) => setEventFormData({ ...eventFormData, eventCoverImage: eventCoverImage })} />
+						<CropImage 
+							eventCoverImage={eventFormData.eventCoverImage}
+							eventCoverImageName={eventFormData.eventCoverImageName}
+							onChange={
+								([eventCoverImage, eventCoverImageName]) => 
+									setEventFormData({ ...eventFormData, eventCoverImage, eventCoverImageName})
+							} 
+						/>
 					</div>
 					<div>
 						<div className="mb-2 block">

--- a/components/admin/rush/EventModal.tsx
+++ b/components/admin/rush/EventModal.tsx
@@ -3,6 +3,8 @@ import { RushCategory } from "@/types/admin/events";
 import { addTwoHours } from "@/utils/date";
 import { Button, Label, Modal, TextInput } from "flowbite-react";
 import DatePicker from "react-datepicker";
+import { CanvasPreview } from "./Image/CanvasPreview";
+import CropImage from "./Image/CropImage";
 
 interface EventModalProps {
 	showModal: boolean,
@@ -25,7 +27,7 @@ export default function EventModal({
 	modifyingEvent,
 }: EventModalProps) {
 	return (
-		<Modal show={showModal} size="md" onClose={onClose} popup>
+		<Modal show={showModal} size="2xl" onClose={onClose} popup>
 			<Modal.Header />
 			<Modal.Body>
 				<div className="space-y-6">
@@ -44,6 +46,13 @@ export default function EventModal({
 							value={eventFormData.eventName}
 							onChange={(e) => setEventFormData({ ...eventFormData, eventName: e.target.value })}
 						/>
+					</div>
+					<div>
+						<div className="mb-2 block">
+							<Label htmlFor="eventCoverImage" value="Event Cover Image" />
+							<span className="text-red-500"> *</span>
+						</div>
+						<CropImage />
 					</div>
 					<div>
 						<div className="mb-2 block">

--- a/components/admin/rush/Image/CanvasPreview.tsx
+++ b/components/admin/rush/Image/CanvasPreview.tsx
@@ -1,0 +1,65 @@
+import { PixelCrop } from 'react-image-crop'
+
+const TO_RADIANS = Math.PI / 180
+
+export async function CanvasPreview(
+  image: HTMLImageElement,
+  canvas: HTMLCanvasElement,
+  crop: PixelCrop,
+  scale = 1,
+  rotate = 0,
+) {
+  const ctx = canvas.getContext('2d')
+
+  if (!ctx) {
+    throw new Error('No 2d context')
+  }
+
+  const scaleX = image.naturalWidth / image.width
+  const scaleY = image.naturalHeight / image.height
+  // devicePixelRatio slightly increases sharpness on retina devices
+  // at the expense of slightly slower render times and needing to
+  // size the image back down if you want to download/upload and be
+  // true to the images natural size.
+  const pixelRatio = window.devicePixelRatio
+  // const pixelRatio = 1
+
+  canvas.width = Math.floor(crop.width * scaleX * pixelRatio)
+  canvas.height = Math.floor(crop.height * scaleY * pixelRatio)
+
+  ctx.scale(pixelRatio, pixelRatio)
+  ctx.imageSmoothingQuality = 'high'
+
+  const cropX = crop.x * scaleX
+  const cropY = crop.y * scaleY
+
+  const rotateRads = rotate * TO_RADIANS
+  const centerX = image.naturalWidth / 2
+  const centerY = image.naturalHeight / 2
+
+  ctx.save()
+
+  // 5) Move the crop origin to the canvas origin (0,0)
+  ctx.translate(-cropX, -cropY)
+  // 4) Move the origin to the center of the original position
+  ctx.translate(centerX, centerY)
+  // 3) Rotate around the origin
+  ctx.rotate(rotateRads)
+  // 2) Scale the image
+  ctx.scale(scale, scale)
+  // 1) Move the center of the image to the origin (0,0)
+  ctx.translate(-centerX, -centerY)
+  ctx.drawImage(
+    image,
+    0,
+    0,
+    image.naturalWidth,
+    image.naturalHeight,
+    0,
+    0,
+    image.naturalWidth,
+    image.naturalHeight,
+  )
+
+  ctx.restore()
+}

--- a/components/admin/rush/Image/CropImage.tsx
+++ b/components/admin/rush/Image/CropImage.tsx
@@ -36,11 +36,15 @@ function centerAspectCrop(
 }
 
 interface CropyImageProps {
-  onChange: (eventCoverImage: File | null) => void;
+  eventCoverImage: string;
+  eventCoverImageName: string;
+  onChange: ([eventCoverImage, eventCoverImageName]: [string, string]) => void;
 }
 
-export default function CropImage({ 
-  onChange
+export default function CropImage({
+  eventCoverImage,
+  eventCoverImageName,
+  onChange,
 }: CropyImageProps) {
   const [imgSrc, setImgSrc] = useState("");
   const [imgName, setImgName] = useState("");
@@ -74,8 +78,8 @@ export default function CropImage({
       // reset completedCrop (no file is chosen)
       setCompletedCrop(undefined);
       
-      // reset eventCoverImage, imgName, amnd imgSrc
-      onChange(null);
+      // reset eventCoverImage/eventCoverImageName, imgName, amnd imgSrc
+      onChange(["", ""]);
 
       setImgName("");
 
@@ -103,11 +107,11 @@ export default function CropImage({
     const scaleX = image.naturalWidth / image.width;
     const scaleY = image.naturalHeight / image.height;
 
-    const offscreen = new OffscreenCanvas(
-      completedCrop.width * scaleX,
-      completedCrop.height * scaleY,
-    )
-    const ctx = offscreen.getContext('2d');
+    // Create an in-memory canvas
+    const canvas = document.createElement('canvas');
+    canvas.width = completedCrop.width * scaleX;
+    canvas.height = completedCrop.height * scaleY;
+    const ctx = canvas.getContext('2d');
     if (!ctx) {
       throw new Error('No 2d context');
     }
@@ -120,17 +124,15 @@ export default function CropImage({
       previewCanvas.height,
       0,
       0,
-      offscreen.width,
-      offscreen.height,
+      canvas.width,
+      canvas.height,
     );
     // You might want { type: "image/jpeg", quality: <0 to 1> } to
     // reduce image size
-    const blob = await offscreen.convertToBlob({
-      type: 'image/png',
-    });
 
-    const file = new File([blob], imgName, { type: "image/png" });
-    onChange(file);
+    // Convert the canvas to a base64 data URL
+    const base64Image = canvas.toDataURL('image/png');
+    onChange([base64Image, imgName]);
 
     // hide ReactCrop editor
     setDisplayReactCrop(false);
@@ -192,7 +194,10 @@ export default function CropImage({
           <Button onClick={onSaveCropClick}>Save Crop</Button>
         </div>
         :
-        <Button onClick={() => setDisplayReactCrop(true)}>Edit Crop</Button>
+        <div>
+          <img src={eventCoverImage} alt={eventCoverImageName} />
+          <Button onClick={() => setDisplayReactCrop(true)}>Edit Crop</Button>
+        </div>
       )}
     </div>
   )

--- a/components/admin/rush/Image/CropImage.tsx
+++ b/components/admin/rush/Image/CropImage.tsx
@@ -36,7 +36,7 @@ function centerAspectCrop(
 }
 
 interface CropyImageProps {
-  onChange: (croppedImage: File) => void;
+  onChange: (eventCoverImage: File | null) => void;
 }
 
 export default function CropImage({ 
@@ -61,6 +61,15 @@ export default function CropImage({
       
       // show ReactCrop editor
       setDisplayReactCrop(true);
+    } else {
+      // show ReactCrop editor
+      setDisplayReactCrop(false);
+      
+      // reset completedCrop (no file is chosen)
+      setCompletedCrop(undefined);
+      
+      // reset eventCoverImage
+      onChange(null);
     }
   }
 

--- a/components/admin/rush/Image/CropImage.tsx
+++ b/components/admin/rush/Image/CropImage.tsx
@@ -1,0 +1,191 @@
+// code inspired by example from https://codesandbox.io/s/react-image-crop-demo-with-react-hooks-y831o?file=/src/App.tsx
+import React, { useState, useRef } from 'react'
+
+import ReactCrop, {
+  centerCrop,
+  makeAspectCrop,
+  Crop,
+  PixelCrop,
+  convertToPixelCrop,
+} from 'react-image-crop'
+import { CanvasPreview } from './CanvasPreview'
+import { useDebounceEffect } from '@/utils/useDebounceEffect'
+import Image from 'next/image'
+import 'react-image-crop/dist/ReactCrop.css'
+
+// This is to demonstate how to make and center a % aspect crop
+// which is a bit trickier so we use some helper functions.
+function centerAspectCrop(
+  mediaWidth: number,
+  mediaHeight: number,
+  aspect: number,
+) {
+  return centerCrop(
+    makeAspectCrop(
+      {
+        unit: '%',
+        width: 90,
+      },
+      aspect,
+      mediaWidth,
+      mediaHeight,
+    ),
+    mediaWidth,
+    mediaHeight,
+  )
+}
+
+export default function CropImage() {
+  const [imgSrc, setImgSrc] = useState('')
+  const previewCanvasRef = useRef<HTMLCanvasElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+  const hiddenAnchorRef = useRef<HTMLAnchorElement>(null)
+  const blobUrlRef = useRef('')
+  const [crop, setCrop] = useState<Crop>()
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>()
+  const aspect = 16 / 9
+
+  function onSelectFile(e: React.ChangeEvent<HTMLInputElement>) {
+    if (e.target.files && e.target.files.length > 0) {
+      setCrop(undefined) // Makes crop preview update between images.
+      const reader = new FileReader()
+      reader.addEventListener('load', () =>
+        setImgSrc(reader.result?.toString() || ''),
+      )
+      reader.readAsDataURL(e.target.files[0])
+    }
+  }
+
+  function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+    if (aspect) {
+      const { width, height } = e.currentTarget
+      setCrop(centerAspectCrop(width, height, aspect))
+    }
+  }
+
+  async function onDownloadCropClick() {
+    const image = imgRef.current
+    const previewCanvas = previewCanvasRef.current
+    if (!image || !previewCanvas || !completedCrop) {
+      throw new Error('Crop canvas does not exist')
+    }
+
+    // This will size relative to the uploaded image
+    // size. If you want to size according to what they
+    // are looking at on screen, remove scaleX + scaleY
+    const scaleX = image.naturalWidth / image.width
+    const scaleY = image.naturalHeight / image.height
+
+    const offscreen = new OffscreenCanvas(
+      completedCrop.width * scaleX,
+      completedCrop.height * scaleY,
+    )
+    const ctx = offscreen.getContext('2d')
+    if (!ctx) {
+      throw new Error('No 2d context')
+    }
+
+    ctx.drawImage(
+      previewCanvas,
+      0,
+      0,
+      previewCanvas.width,
+      previewCanvas.height,
+      0,
+      0,
+      offscreen.width,
+      offscreen.height,
+    )
+    // You might want { type: "image/jpeg", quality: <0 to 1> } to
+    // reduce image size
+    const blob = await offscreen.convertToBlob({
+      type: 'image/png',
+    })
+
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current)
+    }
+    blobUrlRef.current = URL.createObjectURL(blob)
+
+    if (hiddenAnchorRef.current) {
+      hiddenAnchorRef.current.href = blobUrlRef.current
+      hiddenAnchorRef.current.click()
+    }
+  }
+
+  useDebounceEffect(
+    async () => {
+      if (
+        completedCrop?.width &&
+        completedCrop?.height &&
+        imgRef.current &&
+        previewCanvasRef.current
+      ) {
+        // We use canvasPreview as it's much faster than imgPreview.
+        CanvasPreview(
+          imgRef.current,
+          previewCanvasRef.current,
+          completedCrop
+        )
+      }
+    },
+    100,
+    [completedCrop],
+  )
+
+  return (
+    <div className="App">
+      <div className="Crop-Controls">
+        <input type="file" accept="image/*" onChange={onSelectFile} />
+      </div>
+      {!!imgSrc && (
+        <ReactCrop
+          crop={crop}
+          onChange={(_, percentCrop) => setCrop(percentCrop)}
+          onComplete={(c) => setCompletedCrop(c)}
+          aspect={aspect}
+          // minWidth={400}
+          minHeight={100}
+          // circularCrop
+        >
+          <img
+            ref={imgRef}
+            alt="Crop me"
+            src={imgSrc}
+            onLoad={onImageLoad}
+          />
+        </ReactCrop>
+      )}
+      {!!completedCrop && (
+        <>
+          <div>
+            <canvas
+              ref={previewCanvasRef}
+              style={{
+                border: '1px solid black',
+                objectFit: 'contain',
+                width: completedCrop.width,
+                height: completedCrop.height,
+              }}
+            />
+          </div>
+          <div>
+            <button onClick={onDownloadCropClick}>Download Crop</button>
+            <a
+              href="#hidden"
+              ref={hiddenAnchorRef}
+              download
+              style={{
+                position: 'absolute',
+                top: '-200vh',
+                visibility: 'hidden',
+              }}
+            >
+              Hidden download
+            </a>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react": "18.2.0",
         "react-datepicker": "^4.17.0",
         "react-dom": "18.2.0",
+        "react-image-crop": "^11.0.6",
         "react-timestamp": "^6.0.0",
         "recharts": "^2.10.3",
         "tailwindcss": "^3.3.3",
@@ -5091,6 +5092,14 @@
       "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.6.tgz",
+      "integrity": "sha512-T+/RPBhwFxdf8PjD/uoWk+tBkS0Xf2XW0lY5mnsmClvnAujO81EEjDwj0M2pcHX3seXVgKOr/yIiL+Sx4evMNw==",
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "18.2.0",
     "react-datepicker": "^4.17.0",
     "react-dom": "18.2.0",
+    "react-image-crop": "^11.0.6",
     "react-timestamp": "^6.0.0",
     "recharts": "^2.10.3",
     "tailwindcss": "^3.3.3",

--- a/types/admin/events.ts
+++ b/types/admin/events.ts
@@ -22,7 +22,7 @@ export interface UserInEvent{
 }
 
 export interface RushEvent {
-  eventId: string;
+  _id: string;
   name: string;
   dateCreated: string;
   lastModified: string;
@@ -30,6 +30,8 @@ export interface RushEvent {
   location: string;
   date: string;
   deadline: string;
+  eventCoverImage: string;
+  eventCoverImageName: string;
 }
 
 export interface RushCategory {

--- a/utils/useDebounceEffect.tsx
+++ b/utils/useDebounceEffect.tsx
@@ -1,0 +1,17 @@
+import { useEffect, DependencyList } from "react"
+
+export function useDebounceEffect(
+  fn: () => void,
+  waitTime: number,
+  deps?: DependencyList,
+) {
+  useEffect(() => {
+    const t = setTimeout(() => {
+      fn.apply(deps)
+    }, waitTime)
+
+    return () => {
+      clearTimeout(t)
+    }
+  }, [deps])
+}

--- a/utils/useDebounceEffect.tsx
+++ b/utils/useDebounceEffect.tsx
@@ -1,5 +1,8 @@
 import { useEffect, DependencyList } from "react"
 
+// useDebounceEffect : custom React hook that debounces the execution of a given function
+// (used for the CropImage component to ensure the completed crop is only executed every 
+// `waitTime` ms)
 export function useDebounceEffect(
   fn: () => void,
   waitTime: number,


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Integrated [React Image Crop](https://www.npmjs.com/package/react-image-crop) to facilitate uploading `eventCoverImage` and `eventCoverImageName`. This involved sending to an s3 bucket in Zap.

## Type of change

- [ ] Fix: Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor: Any code refactoring
- [ ] Chore: technical debt, workflow improvements
- [x] Feature: New feature (non-breaking change which adds functionality)
- [ ] Documentation: This change requires a documentation update

## Tests Performed

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->


## Screenshots

<!-- Please attach relevant screenshots regarding the PR -->

## Additional Comments
