### PR TITLE
feat: Add video interview question type support

### DIFF
--- a/app/admin/create/page.tsx
+++ b/app/admin/create/page.tsx
@@ -3,21 +3,21 @@ import React, { useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { useRouter } from "next/navigation";
-import { Button, Checkbox, Label, TextInput } from "flowbite-react";
+import { Badge, Button, Checkbox, Label, TextInput } from "flowbite-react";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { AdminTextStyles } from "@/styles/TextStyles";
 import { HiPlus } from "react-icons/hi";
 
 interface FormData {
   title: string;
-  questions: [] | { question: string; context: string }[];
+  questions: [] | { question: string; context: string; type: "text" | "video" }[];
   deadline: Date;
   include_events_attended: boolean;
 }
 
 const initialValues: FormData = {
   title: "",
-  questions: [] as { question: string; context: string }[], // Specify the type here
+  questions: [] as { question: string; context: string; type: "text" | "video" }[],
   deadline: new Date(),
   include_events_attended: true,
 };
@@ -113,10 +113,10 @@ export default function Create() {
     }));
   };
 
-  const handleAddQuestion = () => {
+  const handleAddQuestion = (type: "text" | "video" = "text") => {
     setFormData((prevData) => ({
       ...prevData,
-      questions: [...prevData.questions, { question: "", context: "" }],
+      questions: [...prevData.questions, { question: "", context: "", type }],
     }));
   };
 
@@ -131,15 +131,14 @@ export default function Create() {
 
   const handleQuestionChange = (
     index: number,
-    field: string,
+    field: "question" | "context",
     value: string
   ) => {
     const updatedQuestions = [...formData.questions];
     const questionObj = updatedQuestions[index];
 
     if (questionObj) {
-      // Ensure questionObj is defined
-      questionObj[field as keyof typeof questionObj] = value;
+      questionObj[field] = value;
 
       setFormData((prevData) => ({
         ...prevData,
@@ -179,7 +178,10 @@ export default function Create() {
             ? "None"
             : formData.questions.map((questionObj, index) => (
                 <div className="w-full" key={index}>
-                  <div className="flex justify-end">
+                  <div className="flex justify-between items-center mb-2">
+                    <Badge color={questionObj.type === "video" ? "purple" : "gray"}>
+                      {questionObj.type === "video" ? "Video Response" : "Text Response"}
+                    </Badge>
                     <svg
                       onClick={() => handleRemoveQuestion(index)}
                       className="w-4 h-4 text-gray-800 dark:text-white hover:bg-gray-100"
@@ -203,9 +205,9 @@ export default function Create() {
                       Question <span className="text-red-500">*</span>
                     </label>
                     <TextInput
-                      id={`question-${index}`} // Set a unique id for each question input
+                      id={`question-${index}`}
                       type="text"
-                      placeholder="Question"
+                      placeholder={questionObj.type === "video" ? "e.g., Why do you want to join PCT?" : "Question"}
                       value={questionObj.question}
                       onChange={(e) =>
                         handleQuestionChange(index, "question", e.target.value)
@@ -217,9 +219,9 @@ export default function Create() {
                       Additional Context / Subheadings
                     </label>
                     <TextInput
-                      id={`additional-${index}`} // Set a unique id for each additional input
+                      id={`additional-${index}`}
                       type="text"
-                      placeholder="Add any additional text that explains the question here"
+                      placeholder={questionObj.type === "video" ? "e.g., Upload to YouTube or Google Drive" : "Add any additional text that explains the question here"}
                       value={questionObj.context}
                       onChange={(e) =>
                         handleQuestionChange(index, "context", e.target.value)
@@ -230,13 +232,24 @@ export default function Create() {
                 </div>
               ))}
         </div>
-        <Button
-          onClick={handleAddQuestion}
-          color="light"
-          className="w-full mb-8"
-        >
-          Add Question
-        </Button>
+        <div className="flex gap-2 mb-8">
+          <Button
+            onClick={() => handleAddQuestion("text")}
+            color="light"
+            className="flex-1"
+          >
+            <HiPlus className="mr-2 h-4 w-4" />
+            Add Text Question
+          </Button>
+          <Button
+            onClick={() => handleAddQuestion("video")}
+            color="purple"
+            className="flex-1"
+          >
+            <HiPlus className="mr-2 h-4 w-4" />
+            Add Video Question
+          </Button>
+        </div>
       </div>
     );
   };

--- a/app/admin/create/page.tsx
+++ b/app/admin/create/page.tsx
@@ -7,17 +7,18 @@ import { Badge, Button, Checkbox, Label, TextInput } from "flowbite-react";
 import { useAuth } from "@/app/contexts/AuthContext";
 import { AdminTextStyles } from "@/styles/TextStyles";
 import { HiPlus } from "react-icons/hi";
+import { Question } from "@/types/listing";
 
 interface FormData {
   title: string;
-  questions: [] | { question: string; context: string; type: "text" | "video" }[];
+  questions: Question[];
   deadline: Date;
   include_events_attended: boolean;
 }
 
 const initialValues: FormData = {
   title: "",
-  questions: [] as { question: string; context: string; type: "text" | "video" }[],
+  questions: [],
   deadline: new Date(),
   include_events_attended: true,
 };
@@ -62,13 +63,13 @@ export default function Create() {
     }
   };
 
-  function flattenQuestions(questions: { [key: string]: string }[]): {
+  function flattenQuestions(questions: Question[]): {
     [key: string]: string;
   } {
     // Flatten the 'questions' array into a flat object
     const flattenedQuestions = questions.reduce((acc, question, index) => {
       Object.keys(question).forEach((key) => {
-        acc[`questions[${index}].${key}`] = question[key];
+        acc[`questions[${index}].${key}`] = question[key as keyof Question];
       });
       return acc;
     }, {} as Record<string, string>);

--- a/app/admin/settings/[listingId]/page.tsx
+++ b/app/admin/settings/[listingId]/page.tsx
@@ -131,7 +131,7 @@ export default function ListingSettings({ params }: { params: { listingId: strin
   const handleAddQuestion = () => {
     setFormData((prevData) => ({
       ...prevData,
-goit      questions: [...prevData.questions, { question: "", context: "", type: "text" }],
+      questions: [...prevData.questions, { question: "", context: "", type: "text" }],
     }));
   };
 

--- a/app/admin/settings/[listingId]/page.tsx
+++ b/app/admin/settings/[listingId]/page.tsx
@@ -56,7 +56,7 @@ export default function ListingSettings({ params }: { params: { listingId: strin
           questions: (data.questions ?? []).map(q => ({
             question: q.question,
             context: q.context,
-            type: (q.type ?? "text") as "text" | "video", // Default to "text" for backward compatibility
+            type: q.type ?? "text",
           })),
           deadline: new Date(data.deadline), // Assuming data.deadline is a valid date string
         });

--- a/app/admin/settings/[listingId]/page.tsx
+++ b/app/admin/settings/[listingId]/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { useRouter } from 'next/navigation';
-import { Listing } from "@/types/listing";
+import { Listing, Question } from "@/types/listing";
 import { Button, Modal, TextInput } from 'flowbite-react';
 import CustomAlert from "@/components/admin/settings/CustomAlert";
 import { useAuth } from "@/app/contexts/AuthContext";
@@ -13,7 +13,7 @@ import { AdminTextStyles } from "@/styles/TextStyles";
 
 interface FormData {
   title: string;
-  questions: { [key: string]: string }[];
+  questions: Question[];
   deadline: Date;
 }
 
@@ -53,7 +53,11 @@ export default function ListingSettings({ params }: { params: { listingId: strin
         setListingData(data)
         setFormData({
           title: data.title,
-          questions: data.questions ?? [],
+          questions: (data.questions ?? []).map(q => ({
+            question: q.question,
+            context: q.context,
+            type: (q.type ?? "text") as "text" | "video", // Default to "text" for backward compatibility
+          })),
           deadline: new Date(data.deadline), // Assuming data.deadline is a valid date string
         });
         setSelectedDate(new Date(data.deadline));
@@ -127,7 +131,7 @@ export default function ListingSettings({ params }: { params: { listingId: strin
   const handleAddQuestion = () => {
     setFormData((prevData) => ({
       ...prevData,
-      questions: [...prevData.questions, { question: "", context: "" }],
+goit      questions: [...prevData.questions, { question: "", context: "", type: "text" }],
     }));
   };
 
@@ -140,9 +144,12 @@ export default function ListingSettings({ params }: { params: { listingId: strin
     }));
   };
 
-  const handleQuestionChange = (index: number, field: string, value: string) => {
+  const handleQuestionChange = (index: number, field: "question" | "context", value: string) => {
     const updatedQuestions = [...formData.questions];
-    updatedQuestions[index][field] = value;
+    updatedQuestions[index] = {
+      ...updatedQuestions[index],
+      [field]: value,
+    };
     setFormData((prevData) => ({
       ...prevData,
       questions: updatedQuestions,

--- a/app/public/layout.tsx
+++ b/app/public/layout.tsx
@@ -1,17 +1,13 @@
 "use client"
-import '../globals.css'
 
-
-export default function RootLayout({
+export default function PublicLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
-      <body className="min-w-screen min-h-screen">
-          {children}
-      </body>
-    </html>
+    <div className="min-w-screen min-h-screen">
+      {children}
+    </div>
   )
 }

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -211,11 +211,17 @@ export default function Form({
 
       const normalizedFormData = normalizeFormData(formData);
 
+      const videoIndex = questions.findIndex((q) => q.type === "video");
+      const videoUrl =
+        videoIndex >= 0
+          ? (formData.responses[videoIndex]?.trim() || null)
+          : null;
+
       const dataToSend: DataToSend = {
         ...normalizedFormData,
         listing_id: listingId,
         responses: responseObjects, // Replace the 'responses' array with response objects
-        video_url: formData.video_url?.trim() || null, // Send null if empty
+        video_url: videoUrl,
       };
 
       // Make a POST request to the /apply API endpoint
@@ -295,15 +301,7 @@ export default function Form({
               type="url"
               placeholder="https://drive.google.com/file/d/... or https://youtube.com/watch?v=..."
               value={formData.responses[index] || ""}
-              onChange={(e) => {
-                const value = e.target.value.trim();
-                handleResponseChange(index, value);
-                // Also update video_url field
-                setFormData((prevData) => ({
-                  ...prevData,
-                  video_url: value || null,
-                }));
-              }}
+              onChange={(e) => handleResponseChange(index, e.target.value.trim())}
               disabled={isSubmitting}
               color={
                 formData.responses[index] &&

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -35,7 +35,6 @@ const initialValues: FormData = {
   phone: "",
   linkedin: "",
   website: "",
-  video_url: null,
   resume: null,
   image: null,
   colleges: {
@@ -220,7 +219,7 @@ export default function Form({
       const dataToSend: DataToSend = {
         ...normalizedFormData,
         listing_id: listingId,
-        responses: responseObjects, // Replace the 'responses' array with response objects
+        responses: responseObjects,
         video_url: videoUrl,
       };
 

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -35,6 +35,7 @@ const initialValues: FormData = {
   phone: "",
   linkedin: "",
   website: "",
+  video_url: null,
   resume: null,
   image: null,
   colleges: {
@@ -128,7 +129,11 @@ export default function Form({
       alert(`Incomplete fields. Please fill in all required fields.`);
       return false;
     } else if (
-      formData.responses.some((response) => {
+      formData.responses.some((response, index) => {
+        // Skip word count for video questions
+        if (questions[index]?.type === "video") {
+          return false;
+        }
         if (typeof response === "string") {
           const wordCount = response.trim().split(/\s+/).filter(Boolean).length;
           return wordCount > maxWordCount;
@@ -139,6 +144,18 @@ export default function Form({
       alert(
         `One or more responses are over the maximum word count. Please edit your response.`
       );
+      return false;
+    } else if (
+      // Validate video URLs
+      questions.some((q, index) => {
+        if (q.type === "video") {
+          const response = formData.responses[index];
+          return !response || !response.match(/^https?:\/\/.+/);
+        }
+        return false;
+      })
+    ) {
+      alert(`Please enter a valid video URL starting with http:// or https://`);
       return false;
     } else if (!confirmUndergraduate) {
       alert(
@@ -198,6 +215,7 @@ export default function Form({
         ...normalizedFormData,
         listing_id: listingId,
         responses: responseObjects, // Replace the 'responses' array with response objects
+        video_url: formData.video_url?.trim() || null, // Send null if empty
       };
 
       // Make a POST request to the /apply API endpoint
@@ -260,28 +278,76 @@ export default function Form({
 
   // Component that handles essay questions
   const renderResponseInputs = () => {
-    return questions.map((question, index) => (
-      <div key={index} className="flex flex-col gap-1 mb-6">
-        <label className={AdminTextStyles.default}>
-          {question.question} (Max {maxWordCount} words){" "}
-          <span className="text-red-500">*</span>
-        </label>
-        <Textarea
-          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block w-full p-2.5 h-32"
-          value={formData.responses[index]}
-          onChange={(e) => handleResponseChange(index, e.target.value)}
-          placeholder={question.context}
-          disabled={isSubmitting}
-        />
-        <p className="text-sm text-gray-500">
-          {maxWordCount - getWordCount(formData.responses[index]) + 1 >= 0
-            ? `Remaining words: ${
-                maxWordCount - getWordCount(formData.responses[index])
-              }`
-            : "Remaining words: Over word count!"}
-        </p>
-      </div>
-    ));
+    return questions.map((question, index) => {
+      // Video question - render URL input
+      if (question.type === "video") {
+        return (
+          <div key={index} className="flex flex-col gap-1 mb-6">
+            <label className={AdminTextStyles.default}>
+              {question.question}{" "}
+              <span className="text-red-500">*</span>
+            </label>
+            <p className="text-sm text-gray-500 mb-2">
+              {question.context || "Upload your video to Google Drive or YouTube and paste the link below."}
+            </p>
+            <TextInput
+              id={`video_response_${index}`}
+              type="url"
+              placeholder="https://drive.google.com/file/d/... or https://youtube.com/watch?v=..."
+              value={formData.responses[index] || ""}
+              onChange={(e) => {
+                const value = e.target.value.trim();
+                handleResponseChange(index, value);
+                // Also update video_url field
+                setFormData((prevData) => ({
+                  ...prevData,
+                  video_url: value || null,
+                }));
+              }}
+              disabled={isSubmitting}
+              color={
+                formData.responses[index] &&
+                !formData.responses[index].match(/^https?:\/\/.+/)
+                  ? "failure"
+                  : undefined
+              }
+              helperText={
+                formData.responses[index] &&
+                !formData.responses[index].match(/^https?:\/\/.+/) ? (
+                  <span className="text-red-500">
+                    Please enter a valid URL starting with http:// or https://
+                  </span>
+                ) : undefined
+              }
+            />
+          </div>
+        );
+      }
+
+      // Text question - render textarea (default)
+      return (
+        <div key={index} className="flex flex-col gap-1 mb-6">
+          <label className={AdminTextStyles.default}>
+            {question.question} (Max {maxWordCount} words){" "}
+            <span className="text-red-500">*</span>
+          </label>
+          <Textarea
+            className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-purple-500 focus:border-purple-500 block w-full p-2.5 h-32"
+            value={formData.responses[index]}
+            onChange={(e) => handleResponseChange(index, e.target.value)}
+            placeholder={question.context}
+            disabled={isSubmitting}
+          />
+          <p className="text-sm text-gray-500">
+            {maxWordCount - getWordCount(formData.responses[index]) + 1 >= 0
+              ? `Remaining words: ${
+                  maxWordCount - getWordCount(formData.responses[index])
+                }`
+              : "Remaining words: Over word count!"}
+          </p>
+        </div>
+      );
+    });
   };
 
   const handleChange = (

--- a/components/admin/listing/ApplicantPage.tsx
+++ b/components/admin/listing/ApplicantPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Applicant, EventsAttended } from "@/types/applicant";
 import { Badge, Tabs, Table } from 'flowbite-react';
-import { HiMenuAlt1, HiDocumentText, HiUserGroup } from 'react-icons/hi';
+import { HiMenuAlt1, HiDocumentText, HiUserGroup, HiVideoCamera } from 'react-icons/hi';
 import ResponseCard from "@/components/admin/listing/ResponseCard";
 import ApplicantInfoCard from "@/components/admin/listing/ApplicantInfoCard";
 import ApplicantPDFViewer from "@/components/admin/listing/ApplicantPDFViewer";
@@ -11,19 +11,142 @@ interface ApplicantPageProps {
   applicant: Applicant;
 }
 
+// Helper function to extract YouTube video ID from various URL formats
+const getYouTubeVideoId = (url: string): string | null => {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\s?]+)/,
+    /youtube\.com\/shorts\/([^&\s?]+)/,
+  ];
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+};
+
+// Helper function to check if URL is a Google Drive link
+const isGoogleDriveLink = (url: string): boolean => {
+  return url.includes('drive.google.com');
+};
+
+// Helper function to convert Google Drive URL to embeddable format
+const convertGoogleDriveToEmbed = (url: string): string | null => {
+  // Extract file ID from various Google Drive URL formats
+  const fileIdMatch = url.match(/\/file\/d\/([a-zA-Z0-9_-]+)/);
+  if (fileIdMatch) {
+    return `https://drive.google.com/file/d/${fileIdMatch[1]}/preview`;
+  }
+  return null;
+};
+
+// Helper function to check if a string is a video URL (YouTube or Google Drive)
+const isVideoUrl = (text: string): boolean => {
+  if (!text) return false;
+  const trimmed = text.trim();
+  return (
+    trimmed.includes('youtube.com') ||
+    trimmed.includes('youtu.be') ||
+    trimmed.includes('drive.google.com')
+  );
+};
+
+// Render a video response with embedding
+const renderVideoResponse = (url: string) => {
+  const youtubeId = getYouTubeVideoId(url);
+  if (youtubeId) {
+    return (
+      <div className="aspect-video w-full max-w-3xl">
+        <iframe
+          className="w-full h-full rounded-lg"
+          src={`https://www.youtube.com/embed/${youtubeId}`}
+          title="Video Response"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      </div>
+    );
+  } else if (isGoogleDriveLink(url)) {
+    const embedUrl = convertGoogleDriveToEmbed(url);
+    if (embedUrl) {
+      return (
+        <div className="space-y-2">
+          <div className="aspect-video w-full max-w-3xl">
+            <iframe
+              className="w-full h-full rounded-lg"
+              src={embedUrl}
+              title="Video Response"
+              allow="autoplay"
+              allowFullScreen
+            />
+          </div>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-sm text-purple-600 hover:text-purple-800 dark:text-purple-400 underline"
+          >
+            Open in Google Drive
+          </a>
+        </div>
+      );
+    } else {
+      // Fallback if we can't extract file ID
+      return (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
+        >
+          <HiVideoCamera className="w-5 h-5" />
+          Open Video in Google Drive
+        </a>
+      );
+    }
+  } else {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-purple-600 hover:text-purple-800 dark:text-purple-400 underline break-all"
+      >
+        {url}
+      </a>
+    );
+  }
+};
+
 export default function ApplicantPage({ applicant }: ApplicantPageProps) {
 
   const renderResponses = () => {
     return (
       applicant.responses ? (
         <div>
-          {applicant.responses.map((response, index) => (
-            <ResponseCard
-              key={index}
-              question={response.question}
-              answer={response.response}
-            />
-          ))}
+          {applicant.responses.map((response, index) => {
+            // Check if this response is a video URL (either by URL detection or content)
+            if (isVideoUrl(response.response)) {
+              return (
+                <div key={index} className={`flex flex-col max-w-3xl border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700 mb-4`}>
+                  <div className="p-4 flex flex-row gap-2 items-center rounded-t-lg bg-slate-50 dark:bg-slate-600">
+                    <Badge color="purple">Question</Badge>
+                    <h5 className={AdminTextStyles.default}>{response.question}</h5>
+                  </div>
+                  <div className="p-4">
+                    {renderVideoResponse(response.response)}
+                  </div>
+                </div>
+              );
+            }
+            // Regular text response
+            return (
+              <ResponseCard
+                key={index}
+                question={response.question}
+                answer={response.response}
+              />
+            );
+          })}
         </div>
       ) : (
         <p className={AdminTextStyles.default}>None</p>

--- a/types/applicant.ts
+++ b/types/applicant.ts
@@ -17,6 +17,7 @@ export interface Applicant {
   major:          string;
   phone:          string;
   responses:      Response[] | null;
+  video_url:      string | null;
   colleges:       { [key: string]: boolean };
   events:         { [key: string]: boolean } | null;
   threshold?:     boolean;

--- a/types/form.ts
+++ b/types/form.ts
@@ -20,6 +20,7 @@ export interface FormData {
   phone: string;
   linkedin: string;
   website: string;
+  video_url: string | null;
   resume: File | null;
   image: File | null;
   colleges: {
@@ -48,7 +49,7 @@ export type RequiredFormFields = Array<keyof FormData>;
 
 export interface FormProps {
   title: string | null;
-  questions: [] | { question: string; context: string }[];
+  questions: [] | { question: string; context: string; type?: "text" | "video" }[];
   listingId: string | null;
   includeEventsAttended: boolean;
   isPreview: boolean;

--- a/types/form.ts
+++ b/types/form.ts
@@ -20,7 +20,6 @@ export interface FormData {
   phone: string;
   linkedin: string;
   website: string;
-  video_url: string | null;
   resume: File | null;
   image: File | null;
   colleges: {
@@ -40,9 +39,11 @@ export interface FormData {
   responses: string[];
 }
 
-export interface DataToSend extends Omit<FormData, 'responses'>  {
-  listing_id: string
-  responses: { question: string; response: string }[]
+export interface DataToSend extends Omit<FormData, 'responses'> {
+  listing_id: string;
+  responses: { question: string; response: string }[];
+  // Derived at submit time from video question responses, not stored in form state 
+  video_url: string | null;
 }
 
 export type RequiredFormFields = Array<keyof FormData>;

--- a/types/listing.ts
+++ b/types/listing.ts
@@ -1,3 +1,4 @@
+// NOTE: ensure backwards compatability if this type is ever changed (this type is the source of what is saved in DB)
 export interface Question {
   question: string;
   context: string;

--- a/types/listing.ts
+++ b/types/listing.ts
@@ -1,3 +1,9 @@
+export interface Question {
+  question: string;
+  context: string;
+  type: "text" | "video";
+}
+
 export interface Listing {
   id: string;
   title: string;
@@ -7,5 +13,5 @@ export interface Listing {
   is_encrypted: boolean;
   is_visible: boolean;
   include_events_attended: boolean;
-  questions: { question: string; context: string }[] | null;
+  questions: Question[] | null;
 }


### PR DESCRIPTION
## What does this PR do?

Added video interview question type support alongside normal written-response question types. 

- Add question type field (text/video) to listing questions
- Render URL input for video questions in applicant form
- Embed YouTube and Google Drive videos in admin applicant view
- Validate video URLs and store in video_url field

## Type of change

- [ ] Fix: Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor: Any code refactoring
- [ ] Chore: technical debt, workflow improvements
- [ x] Feature: New feature (non-breaking change which adds functionality)
- [ ] Documentation: This change requires a documentation update

## Tests Performed

- Verified video URL validation (rejects invalid URLs, accepts http/https) and storage in database
- Tested end-to-end flow on local development environment 
- Tested existing applications without video_url continue to work correctly